### PR TITLE
Fix hidden apply button in landscape (ethernet tab).

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -188,13 +188,13 @@
                                     android:singleLine="true" />
                             </LinearLayout>
                         </LinearLayout>
-                    </LinearLayout>
-					</ScrollView>
                         <Button
                             android:id="@+id/button_ethernet_apply"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/apply" />
+                    </LinearLayout>
+					</ScrollView>
                 </LinearLayout>
 
                 <LinearLayout


### PR DESCRIPTION
When you choose static IP address and you use ODROID-VU7 Plus in landscape mode apply button is unavailable to tap. This PR fix it.